### PR TITLE
3.2.11 release download and notes

### DIFF
--- a/content/Gemfile
+++ b/content/Gemfile
@@ -17,4 +17,5 @@ source 'https://rubygems.org'
 gem 'github-pages'
 gem 'rouge'
 gem 'jekyll-oembed', :require => 'jekyll_oembed'
+gem 'jekyll-liquify'
 # End Gemfile

--- a/content/_config.yml
+++ b/content/_config.yml
@@ -27,5 +27,8 @@ baseurl: /
 # baseurl: /Users/cs/adina/ryawebsite/target/
 
 url: http://rya.apache.org
+
+gems:
+  - jekyll-liquify
 # End _config.yml
 

--- a/content/_posts/2017-10-10-release-3.2.11.md
+++ b/content/_posts/2017-10-10-release-3.2.11.md
@@ -1,0 +1,51 @@
+---
+layout: post
+date: "2017-10-10"
+title: Release 3.2.11
+description: details of the second release of Rya (Incubating)
+version: 3.2.11
+fullVersion: rya-incubating-3.2.11
+filename: rya-project-3.2.11-incubating-source-release
+releaseNotes:  "{% post_url 2017-10-10-relnotes-3.2.11 %}"
+categories: [release]
+---
+{% comment %}
+Some of the variables above are used on the summary page that iterates through posts where catagories=release.
+{% endcomment %}{% capture apacheDistMirror %}http://www.apache.org/dyn/closer.lua/{{ site.data.project.incubator_slash_name }}/{{ page.fullVersion }}{% endcapture %}
+{% capture d %}https://dist.apache.org/repos/dist/release/{{ site.data.project.incubator_slash_name }}/{{ page.fullVersion }}{% endcapture %}
+
+
+
+
+
+This is Rya's second Apache release, version {{ page.version }}.  It is available as a source code download:
+
+- [Source download from Apache]({{ apacheDistMirror }}/{{ page.filename }}.zip)
+- Verify: {% comment %}
+{% endcomment %} [pgp]( {{ d }}/{{ page.filename }}.zip.asc ){% comment %}
+{% endcomment %} [md5]( {{ d }}/{{ page.filename }}.zip.md5 ){% comment %}
+{% endcomment %} [sha1]({{ d }}/{{ page.filename }}.zip.sha1){% comment %}
+{% endcomment %} [sha512]({{ d }}/{{ page.filename }}.zip.sha512)
+- [Release notes]({{ page.releaseNotes | liquify }})
+- [Central repository for Maven and other dependency managers](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.rya%22)
+
+[Verify](http://www.apache.org/dyn/closer.cgi#verify)
+using the corresponding *pgp* signature (using the committer file in
+[KEYS](http://www.apache.org/dist/{{ site.data.project.incubator_slash_name }}/KEYS)).
+If you cannot do that, the *md5* or *sha1* hash file may be used to check that the
+download has completed okay.
+
+For fast downloads, current source distributions are hosted on mirror servers;
+older source distributions are in the
+[archive](http://archive.apache.org/dist/incubator/{{ site.data.project.unix_name }}/).
+If a download from a mirror fails, retry, and the second download will likely
+succeed.
+
+For security, hash and signature files are always hosted at
+[Apache](https://www.apache.org/dist/{{ site.data.project.incubator_slash_name }}).
+
+Next steps:
+- [Building from Source](https://github.com/apache/incubator-rya/blob/rel/{{ page.fullVersion }}/extras/rya.manual/src/site/markdown/build-source.md)
+- [Quick Start](https://github.com/apache/incubator-rya/blob/rel/{{ page.fullVersion }}/extras/rya.manual/src/site/markdown/quickstart.md)
+- [Typical First Steps](https://github.com/apache/incubator-rya/blob/rel/{{ page.fullVersion }}/extras/rya.manual/src/site/markdown/sm-firststeps.md)
+- [Manual -- includes documents above](https://github.com/apache/incubator-rya/blob/rel/{{ page.fullVersion }}/extras/rya.manual/src/site/markdown/index.md)

--- a/content/_posts/2017-10-10-relnotes-3.2.11.md
+++ b/content/_posts/2017-10-10-relnotes-3.2.11.md
@@ -1,0 +1,42 @@
+---
+layout: post
+date: "2017-10-10"
+title: Release Notes v3.2.11
+description: Details of what changed in v3.2.11 of Rya (Incubating)
+categories: [releasenotes]
+jira: https://issues.apache.org/jira/browse/
+---
+Release Notes v3.2.11
+
+See the full [list of issues](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12319020&version=12341279) resolved in this release.
+
+Here are the release highlights:
+
+*    [RYA-109]({{page.jira}}RYA-109) - Spark support
+
+*    [RYA-121]({{page.jira}}RYA-121) - Store contextual metadata for individual triples
+
+*    [RYA-231]({{page.jira}}RYA-231) - Revived Giraph Support
+
+*    [RYA-232]({{page.jira}}RYA-232) - Created a Mongo profile for deploying the rest service
+
+*    [RYA-241]({{page.jira}}RYA-241) - Geowave support
+
+*    [RYA-290]({{page.jira}}RYA-290) - Expand query inference to support additional RDFS/OWL terms: owl:hasValue, owl:intersectionOf, owl:unionOf, owl:someValuesFrom, owl:allValuesFrom, owl:hasSelf, owl:equivalentClass, rdfs:domain, rdfs:range, owl:oneOf, owl:ReflexiveProperty
+
+*    [RYA-337]({{page.jira}}RYA-337) - Enabled query batching for MongoDB DAO. Previously, the MongoDB DAO sent one Statement Pattern query at a time to Mongo.  Now, the DAO batches Statement Pattern queries and performs a client side join (like the Accumulo DAO).
+
+*    [RYA-323]({{page.jira}}RYA-323) - Enabled Multi Var Geo Functions. Previously, all Rya GeoSPARQL functions required that at least one parameter was a constant (eg "geof:sfWithin(?wkt, "POLYGON(( ... )))" ).  now, we can solve filters that have no constants (eg "geof:near(?wkt2, ?wkt1))")
+
+*    [RYA-185]({{page.jira}}RYA-185) - Add load statements from local file command to Rya shell
+
+*    [RYA-219]({{page.jira}}RYA-219) - Add support for exporting to Kafka for the rya trigger service
+
+*    [RYA-246]({{page.jira}}RYA-246) - Separate Fluo query result exporters, Rya PCJ intermingled kafka triggers
+
+*    [RYA-257]({{page.jira}}RYA-257) - Add Geospacial and Temporal combined indexing support for Mongo backed Rya
+
+*    [RYA-83]({{page.jira}}RYA-83) - The match everything query is now supported: select * where { s? p? o? } 
+
+*    [RYA-339]({{page.jira}}RYA-339) - Fluo PCJ Improvements
+

--- a/content/download.md
+++ b/content/download.md
@@ -54,8 +54,10 @@ Release          | Date       | Download | Notes
 {% endcomment %} [pgp]( {{ d }}/{{ post.filename }}.zip.asc ){% comment %}
 {% endcomment %} [md5]( {{ d }}/{{ post.filename }}.zip.md5 ){% comment %}
 {% endcomment %} [sha1]({{ d }}/{{ post.filename }}.zip.sha1){% comment %}
+{% endcomment %}{% if post.version != "3.2.10" %} [sha512]({{ d }}/{{ post.filename }}.zip.sha512){% comment %}
 {% endcomment %}{% endif %}{% comment %}
-{% endcomment %} | [Release notes]({{ post.releaseNotes }})
+{% endcomment %}{% endif %}{% comment %}
+{% endcomment %} | [Release notes]({{ post.releaseNotes | liquify }})
 {% endfor %}
 <br>
 Download a source distribution in <!-- either *tar* or --> *zip* format,


### PR DESCRIPTION
also added sha512 conditionally to the download page and added the liquefy gem so the release notes URL tag can be parsed.